### PR TITLE
Use new DateTime instance returned

### DIFF
--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -217,7 +217,7 @@ class PowerPoint2007 implements ReaderInterface
                 if ($oElement instanceof \DOMElement) {
                     if ($oElement->hasAttribute('xsi:type') && $oElement->getAttribute('xsi:type') == 'dcterms:W3CDTF') {
                         $oDateTime = new \DateTime();
-                        $oDateTime->createFromFormat(\DateTime::W3C, $oElement->nodeValue);
+                        $oDateTime = $oDateTime->createFromFormat(\DateTime::W3C, $oElement->nodeValue);
                         $oProperties->{$property}($oDateTime->getTimestamp());
                     } else {
                         $oProperties->{$property}($oElement->nodeValue);


### PR DESCRIPTION
DateTime::createFromFormat does not modify the current DateTime instance
used.

https://github.com/PHPOffice/PHPPresentation/pull/571